### PR TITLE
Set welcome page title to blue

### DIFF
--- a/src/app/welcome/page.tsx
+++ b/src/app/welcome/page.tsx
@@ -119,7 +119,7 @@ const WelcomePage = () => {
         
         <Container className="relative z-10">
           <Flex direction="col" align="center" justify="center" className="text-center py-12">
-            <Heading level={1} variant="display" className="text-gray-800 mb-6 max-w-3xl">
+            <Heading level={1} variant="display" className="text-blue-600 mb-6 max-w-3xl">
               Welcome to Kamunity - What&apos;s Your Perspective?
             </Heading>
             


### PR DESCRIPTION
## Summary
- update the welcome page hero heading to use a blue text color for consistency with the page theme

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d0caed9e6883249b0c8e0e0da6c9b0